### PR TITLE
fix golangci linter failed, update golang ci version

### DIFF
--- a/tests/run-linter.sh
+++ b/tests/run-linter.sh
@@ -14,7 +14,7 @@ function log {
 function install_golangci_lint {
     if ! command -v golangci-lint 1>/dev/null 2>&1; then
         log "Install golangci-lint"
-        curl -sfL https://install.goreleaser.com/github.com/golangci/golangci-lint.sh | bash -s -- -b "$(go env GOPATH)/bin" v1.12.2
+        curl -sfL https://install.goreleaser.com/github.com/golangci/golangci-lint.sh | bash -s -- -b "$(go env GOPATH)/bin" v1.16.0
     fi
 }
 


### PR DESCRIPTION
golangci linter cannot pass `typecheck`, take this [PR](https://github.com/github/vulcanizer/pull/42) as the reference, update the golangci-linter version to fix `typecheck` error.

Signed-off-by: JenTing Hsiao <jenting.hsiao@suse.com>